### PR TITLE
a11y: Remove focus outline overrides

### DIFF
--- a/app/assets/stylesheets/admin/adminpages.scss
+++ b/app/assets/stylesheets/admin/adminpages.scss
@@ -6,7 +6,6 @@ html,body {
     margin: 0;
     padding: 0;
     border: 0;
-    outline: 0;
     font-size: 100%;
     vertical-align: baseline;
     background: transparent;

--- a/app/assets/stylesheets/inklewriter.css.scss
+++ b/app/assets/stylesheets/inklewriter.css.scss
@@ -68,7 +68,6 @@ article {
     margin: 0;
     padding: 0;
     border: 0;
-    outline: 0;
     font-size: 100%;
     vertical-align: baseline;
     background: transparent;
@@ -95,10 +94,6 @@ q:before,
 q:after {
     content: '';
     content: none
-}
-
-:focus {
-    outline: 0
 }
 
 ins {

--- a/assets/stylesheets/reset.css.scss
+++ b/assets/stylesheets/reset.css.scss
@@ -21,7 +21,6 @@ table, caption, tbody, tfoot, thead, tr, th, td, article {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	outline: 0;
 	font-size: 100%;
 	vertical-align: baseline;
 	background: transparent;
@@ -40,11 +39,6 @@ blockquote:before, blockquote:after,
 q:before, q:after {
 	content: '';
 	content: none;
-}
-
-/* remember to define focus styles! */
-:focus {
-	outline: 0;
 }
 
 /* remember to highlight inserts somehow! */


### PR DESCRIPTION
Addresses #75 for current semantically-interactive elements. This is anchor links and inputs in write mode.

It seems like only the `inklewriter.css.scss` impacted the main app (I'm not sure yet how to access "admin pages") but I thought I'd be thorough, just in case.

After this change, links and inputs get browser-native focus rings. This may not look pretty -- it exposes some funky padding on some elements -- but it helps keyboard users navigate the page.